### PR TITLE
correct julia versions that can run Kezdi

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,8 @@ jobs:
       matrix:
         version:
           - '1.11'
+          - '1.10'
+          - '1.9'
         os:
           - ubuntu-latest
           - windows-latest

--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,7 @@ ReadStatTables = "0.3"
 Reexport = "1"
 Statistics = "1"
 StatsBase = "0.34"
-julia = "1.11"
+julia = ">= 1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
### Summary
Correct the compatible Julia versions in Project.toml.

### Related Issues
- #195 

### Number of Passing Unit Tests
Tests passing: 520/520

### Checklist
- [ ] Version number has been bumped in Project.toml
#### Tests
- [x] `] test` runs without errors
- [ ] Unit tests have been added 
- [ ] This is a refactoring, no new tests required
#### Documentation
- [ ] Documentation has been updated
- [ ] No change to public API, documentation not required
